### PR TITLE
Исправление ошибки: обновление пула коннектов к БД.

### DIFF
--- a/src/cherrybase/db/base.py
+++ b/src/cherrybase/db/base.py
@@ -224,6 +224,11 @@ class ThreadedPool (object):
         except:
             pass
 
+        for thread_index in list(self.used.keys()):
+            if self.used [thread_index] == connection:
+                del self.used [thread_index]
+        if connection in self.pool:
+            self.pool.remove (connection)
         if connection in self.timeouts:
             del self.timeouts [connection]
 


### PR DESCRIPTION
Исправление ошибки: ThreadPool._removeconn() закрывал connection, но не удалял его из пула открытых либо используемых соединений. В результате, пул коннектов не обновлялся по timeout'у.