### PR TITLE
Исправлена ошибка в ThreadedPool._putconn.

### DIFF
--- a/src/cherrybase/db/base.py
+++ b/src/cherrybase/db/base.py
@@ -207,10 +207,10 @@ class ThreadedPool (object):
 
     def _putconn (self, connection):
         key = self._thread.get_ident ()
+        if key in self.used:
+            del self.used [key]
         if len (self.pool) < self.min_connections:
             self.pool.append (connection)
-            if key in self.used:
-                del self.used [key]
             self._idleconn (connection)
         else:
             connection.close ()


### PR DESCRIPTION
Соединение не удалялось из self.used при его закрытии, что приводило к следующим ошибка:
1. Выдавалось уже закрытое соединение из self.used. Явно проявляется при self.min_connections = 0.
2. Через некоторое время self.used заполняется и соединения перестают выдаваться, т.к. срабатывает условие -
   ```python
   if len (self.used) == self.max_connections:
       raise ThreadedPool.Empty ('Connection pool exausted')
   ```